### PR TITLE
Update Skiko to v0.144.1

### DIFF
--- a/arts/bubbles/src/main/kotlin/dev/oblac/gart/bubbles/pebble/Pebbles.kt
+++ b/arts/bubbles/src/main/kotlin/dev/oblac/gart/bubbles/pebble/Pebbles.kt
@@ -83,18 +83,28 @@ private fun draw(c: Canvas, d: Dimension) {
     pebs.forEach {
         repeat(10) { ndx ->
             c.save()
-            val last = it.lastPt
+            val last = it.lastPt!!
             //c.translate(-last.x, -last.y)
-            val target = Path()
-            it.transform(
+            // alternative in 0.144.0:
+//            target.addPath(
+//                it,
+//                Matrix33.multiply(
+//                    Matrix33.multiply(
+//                        Matrix33.makeTranslate(last.x, last.y),
+//                        Matrix33.makeScale(1.2f - ndx * 0.01f)
+//                    ),
+//                    Matrix33.makeTranslate(-last.x, -last.y),
+//                )
+//            )
+            val target = PathBuilder(it).transform(
                 Matrix33.multiply(
                     Matrix33.multiply(
                         Matrix33.makeTranslate(last.x, last.y),
                         Matrix33.makeScale(1.2f - ndx * 0.01f)
                     ),
                     Matrix33.makeTranslate(-last.x, -last.y),
-                ), target
-            )
+                )
+            ).detach()
             c.drawPath(target, strokeOf(1.1f, RetroColors.red01).apply {
                 //this.pathEffect = PathEffect.makeDash(floatArrayOf(100f + rndf(10f, 20f), rndf(10f, 50f)), rndf(1f, 100f))
             })

--- a/arts/bubbles/src/main/kotlin/dev/oblac/gart/bubbles/stripe2/BubbleStripe2.kt
+++ b/arts/bubbles/src/main/kotlin/dev/oblac/gart/bubbles/stripe2/BubbleStripe2.kt
@@ -12,7 +12,7 @@ import dev.oblac.gart.math.rndf
 import dev.oblac.gart.pack.simpleCirclePacker
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.ClipMode
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathEffect
 
 fun main() {
@@ -30,7 +30,7 @@ fun main() {
     g.draw(draw)
     gart.saveImage(g)
 
-    w.show(draw).hotReload(g)
+    w.show(draw)//.hotReload(g)
 }
 
 private class MyDraw(g: Gartvas) : Drawing(g) {
@@ -47,7 +47,7 @@ private fun draw(c: Canvas, d: Dimension) {
     val r = d.rect
     val box = d.rect.shrink(40f)
 
-    val path = Path()
+    val path = PathBuilder()
     val templates = simpleCirclePacker(
         r,
         attempts = 100_000,
@@ -59,7 +59,7 @@ private fun draw(c: Canvas, d: Dimension) {
     templates.forEach {
         path.addCircle(it)
     }
-    c.clipPath(path, ClipMode.INTERSECT, true)
+    c.clipPath(path.detach(), ClipMode.INTERSECT, true)
 
     val bubbles = simpleCirclePacker(
         r,

--- a/arts/cotton/src/main/kotlin/dev/oblac/gart/cotton/circles/CottonCircles.kt
+++ b/arts/cotton/src/main/kotlin/dev/oblac/gart/cotton/circles/CottonCircles.kt
@@ -10,7 +10,7 @@ import dev.oblac.gart.util.loop
 import dev.oblac.gart.util.randomExcept
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Paint
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Rect
 
 val gart = Gart.of(
@@ -65,6 +65,6 @@ fun drawRectCircle(c: Canvas, x: Float, y: Float, delta: Int, colors: List<Paint
         else -> throw IllegalStateException()
     }
 
-    c.drawPath(Path().addArc(r, 90f * rnd, 180f).closePath(), circleFill)
+    c.drawPath(PathBuilder().addArc(r, 90f * rnd, 180f).closePath().detach(), circleFill)
 }
 

--- a/arts/cotton/src/main/kotlin/dev/oblac/gart/cotton/circles2/CottonCircles2.kt
+++ b/arts/cotton/src/main/kotlin/dev/oblac/gart/cotton/circles2/CottonCircles2.kt
@@ -111,8 +111,8 @@ fun drawCCircle(
         val c2 = color2.makeClone().also { it.alpha = 255 - a * 50 }
 
         val xx = a * 40f
-        c.drawPath(Path().addArc(rect, angle + a * 20f, 180f + xx).closePath(), c1)
-        c.drawPath(Path().addArc(rect, angle + a * 20f + 180f, 180f - xx).closePath(), c2)
+        c.drawPath(PathBuilder().addArc(rect, angle + a * 20f, 180f + xx).closePath().detach(), c1)
+        c.drawPath(PathBuilder().addArc(rect, angle + a * 20f + 180f, 180f - xx).closePath().detach(), c2)
     }
 
 }

--- a/arts/hills/src/main/kotlin/dev/oblac/gart/hills/Hill.kt
+++ b/arts/hills/src/main/kotlin/dev/oblac/gart/hills/Hill.kt
@@ -5,6 +5,7 @@ import dev.oblac.gart.math.GaussianFunction
 import dev.oblac.gart.math.map
 import dev.oblac.gart.noise.PerlinNoise
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathFillMode
 import org.jetbrains.skia.Point
 import kotlin.math.abs
@@ -41,10 +42,7 @@ class Hill(private val dIn: Dimension, private val offsetY: Float) {
         noiseOffset = patternOffset
         dots = dots(tickOffset)
 
-        val path = Path()
-            .apply {
-                fillMode = PathFillMode.EVEN_ODD
-            }
+        val path = PathBuilder()
             .moveTo(0f, offsetY)
 
         for (i in 0 until segments) {
@@ -58,11 +56,13 @@ class Hill(private val dIn: Dimension, private val offsetY: Float) {
         }
 
 
-        path.lineTo(d.wf, offsetY)
+        return path.lineTo(d.wf, offsetY)
             .lineTo(d.wf, d.hf)
             .lineTo(0f, d.hf)
             .closePath()
-
-        return path
+            .detach()
+            .apply {
+                fillMode = PathFillMode.EVEN_ODD
+            }
     }
 }

--- a/arts/hills/src/main/kotlin/dev/oblac/gart/hills/Hills.kt
+++ b/arts/hills/src/main/kotlin/dev/oblac/gart/hills/Hills.kt
@@ -10,6 +10,7 @@ import dev.oblac.gart.math.rndf
 import dev.oblac.gart.noise.poissonDiskSamplingNoise
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import kotlin.math.cos
 import kotlin.math.sin
@@ -66,16 +67,19 @@ fun drawTriangle(c: Canvas) {
     val vY = -d * cos(alpha) + t.y
     val v = Point(vX, vY)
 
-    val p = Path()
+    val p = PathBuilder()
         .moveTo(b1)
         .lineTo(b2)
         .lineTo(v)
         .lineTo(b1)
         .closePath()
+        .detach()
 
     c.drawPath(p, fillOf(ship))
-    p.offset(16f, 16f)
-    c.drawPath(p, strokeOf(ship, 2f))
+    
+    val p2 = PathBuilder(p).offset(16f, 16f).detach()
+    //p.offset(16f, 16f)
+    c.drawPath(p2, strokeOf(ship, 2f))
 }
 
 fun drawStars(c: Canvas, d: Dimension) {
@@ -88,12 +92,18 @@ fun drawStars(c: Canvas, d: Dimension) {
 }
 
 fun drawHill(c: Canvas, p: Path) {
-    p.offset(-20f, 0f)  // the generation of the hill is shifted to the right by 40 pixels
+    // fixme 0.144.0
+    //p.offset(-20f, 0f)  // the generation of the hill is shifted to the right by 40 pixels
+    c.save()
+    c.translate(-20f, 0f)  // the generation of the hill is shifted to the right by 40 pixels
     for (off in 0..14) {
-        p.offset(rndf(-40, 40), off.toFloat() * 10)
+        // fixme 0.144.0
+        c.translate(rndf(-40, 40), off.toFloat() * 10)
+        //p.offset(rndf(-40, 40), off.toFloat() * 10)
         c.drawPath(p, fillOf(blue))
         c.drawPath(p, strokeOf(hill, 4f))
     }
+    c.restore()
 }
 
 fun drawSun(c: Canvas, d: Dimension) {

--- a/arts/hills/src/main/kotlin/dev/oblac/gart/hills2/Hill2.kt
+++ b/arts/hills/src/main/kotlin/dev/oblac/gart/hills2/Hill2.kt
@@ -7,6 +7,7 @@ import dev.oblac.gart.hills.variety
 import dev.oblac.gart.math.GaussianFunction
 import dev.oblac.gart.math.map
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathFillMode
 import org.jetbrains.skia.Point
 import kotlin.math.abs
@@ -39,10 +40,7 @@ class Hill2(dIn: Dimension, private val offsetY: Float, private val gaussDeltaOf
         noiseOffset = patternOffset
         dots = dots(tickOffset)
 
-        val path = Path()
-            .apply {
-                fillMode = PathFillMode.EVEN_ODD
-            }
+        val path = PathBuilder()
             .moveTo(0f, offsetY)
 
         for (i in 0 until segments) {
@@ -61,7 +59,10 @@ class Hill2(dIn: Dimension, private val offsetY: Float, private val gaussDeltaOf
             .lineTo(0f, d.hf)
             .closePath()
 
-        return path
+        return path.detach().apply {
+            fillMode = PathFillMode.EVEN_ODD
+        }
+
     }
 }
 

--- a/arts/hills/src/main/kotlin/dev/oblac/gart/hills2/Hills2.kt
+++ b/arts/hills/src/main/kotlin/dev/oblac/gart/hills2/Hills2.kt
@@ -10,6 +10,7 @@ import dev.oblac.gart.math.rndf
 import dev.oblac.gart.noise.poissonDiskSamplingNoise
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 
 val back = NipponColors.col235_SHIRONEZUMI
 val border = NipponColors.col233_SHIRONERI
@@ -48,9 +49,11 @@ fun main() {
     w.showImage(g)
 }
 
-fun drawHill(c: Canvas, d: Dimension, p: Path, color1: Int, color2: Int) {
-    p.offset(-20f, 0f)  // the generation of the hill is shifted to the right by 40 pixels
-    c.drawPath(p, fillOf(color1))
+private fun drawHill(c: Canvas, d: Dimension, p: Path, color1: Int, color2: Int) {
+    // the generation of the hill is shifted to the right by 40 pixels
+    val p2 = PathBuilder(p).offset(-20f, 0f).detach()
+    //p.offset(-20f, 0f)
+    c.drawPath(p2, fillOf(color1))
     //c.drawPath(p, strokeOf(hill, 4f))
 
     val region = p.toRegion()

--- a/arts/joydiv/src/main/kotlin/dev/oblac/gart/joydiv/Line.kt
+++ b/arts/joydiv/src/main/kotlin/dev/oblac/gart/joydiv/Line.kt
@@ -6,7 +6,7 @@ import dev.oblac.gart.math.GaussianFunction
 import dev.oblac.gart.math.map
 import dev.oblac.gart.noise.PerlinNoise
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathFillMode
 import org.jetbrains.skia.Point
 import kotlin.math.abs
@@ -14,63 +14,64 @@ import kotlin.random.Random
 
 const val segments = 50
 val gap = w / segments
-val gauss = GaussianFunction(100, segments/2, 8)
+val gauss = GaussianFunction(100, segments / 2, 8)
 fun gaussianCurve(x: Number) = gauss(x)
 const val variety = 0.04f
 val perlin = PerlinNoise()
 
 class Line(private val offsetY: Float) {
 
-	private var tickOffset = 0f
-	private val patternOffset = Random.nextInt(300).toFloat()
-	private var dots = dots(tickOffset)
+    private var tickOffset = 0f
+    private val patternOffset = Random.nextInt(300).toFloat()
+    private var dots = dots(tickOffset)
 
-	private var noiseOffset = patternOffset
-	private fun dots(noiseOffsetY: Float) = Array(segments + 1) {
-		val x = gap * it
-		// simple
+    private var noiseOffset = patternOffset
+    private fun dots(noiseOffsetY: Float) = Array(segments + 1) {
+        val x = gap * it
+        // simple
 //		val distanceFromCenter = abs(g.w_2 - x)
 //		val variance = max(g.w_2 - 50 - distanceFromCenter, 0)
 //		val random = Random.nextFloat() * variance / 2 * -1
 //		val y = offsetY + random
 //		Point(x, y)
 
-		// noise lines
-		val noiseValue = perlin.noise(noiseOffset, noiseOffsetY)
-		val gaussValue = gaussianCurve(it)
-		val value = abs(map(noiseValue, 0, 1, -gaussValue, gaussValue))
+        // noise lines
+        val noiseValue = perlin.noise(noiseOffset, noiseOffsetY)
+        val gaussValue = gaussianCurve(it)
+        val value = abs(map(noiseValue, 0, 1, -gaussValue, gaussValue))
 
-		noiseOffset += variety
-		Point(x.toFloat(), offsetY - value)
-	}
+        noiseOffset += variety
+        Point(x.toFloat(), offsetY - value)
+    }
 
     fun draw(canvas: Canvas) {
-		tickOffset += 0.005f
-		noiseOffset = patternOffset
-		dots = dots(tickOffset)
+        tickOffset += 0.005f
+        noiseOffset = patternOffset
+        dots = dots(tickOffset)
 
-		val path = Path()
-            .apply {
-                fillMode = PathFillMode.EVEN_ODD
-            }
-			.moveTo(0f, offsetY)
+        val path = PathBuilder()
+            .moveTo(0f, offsetY)
 
-		for (i in 0 until segments) {
-			// straight lines
-			//path.lineTo(dots[i])
+        for (i in 0 until segments) {
+            // straight lines
+            //path.lineTo(dots[i])
 
-			// quad lines
-			val xc = (dots[i].x + dots[i + 1].x) / 2
-			val yc = (dots[i].y + dots[i + 1].y) / 2
-			path.quadTo(dots[i], Point(xc, yc))
-		}
+            // quad lines
+            val xc = (dots[i].x + dots[i + 1].x) / 2
+            val yc = (dots[i].y + dots[i + 1].y) / 2
+            path.quadTo(dots[i], Point(xc, yc))
+        }
 
-		path.lineTo(wf, offsetY)
-			.lineTo(wf, hf)
-			.lineTo(0f, hf)
-			.closePath()
+        path.lineTo(wf, offsetY)
+            .lineTo(wf, hf)
+            .lineTo(0f, hf)
+            .closePath()
 
-        canvas.drawPath(path, fillOfBlack())
-        canvas.drawPath(path, strokeOfWhite(2f))
-	}
+        val ppath = path.detach().apply {
+            fillMode = PathFillMode.EVEN_ODD
+        }
+
+        canvas.drawPath(ppath, fillOfBlack())
+        canvas.drawPath(ppath, strokeOfWhite(2f))
+    }
 }

--- a/arts/kaleiircle/src/main/kotlin/dev/oblac/gart/kaleidoscope/Kaleidoscope.kt
+++ b/arts/kaleiircle/src/main/kotlin/dev/oblac/gart/kaleidoscope/Kaleidoscope.kt
@@ -10,11 +10,11 @@ import dev.oblac.gart.gfx.drawCircle
 import dev.oblac.gart.gfx.fillOf
 import dev.oblac.gart.gfx.strokeOf
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 
 fun main() {
-    val gart = Gart.Companion.of("kaleidoscope", 1024, 1024)
+    val gart = Gart.of("kaleidoscope", 1024, 1024)
     println(gart)
 
     val d = gart.d
@@ -81,7 +81,7 @@ private fun drawTemplateImage(c: Canvas, d: Dimension) {
         val amplitude = 20f
         val frequency = 0.05f
         val offset = 100f
-        val path = Path()
+        val path = PathBuilder()
         path.moveTo(0f, y)
         var x = 0f
         while (x <= d.wf) {
@@ -89,7 +89,7 @@ private fun drawTemplateImage(c: Canvas, d: Dimension) {
             path.lineTo(x, yy)
             x += step
         }
-        c.drawPath(path, strokeOf(pal.safe(y * 2), 8f))
+        c.drawPath(path.detach(), strokeOf(pal.safe(y * 2), 8f))
     }
 
 }

--- a/arts/kaleiircle/src/main/kotlin/dev/oblac/gart/kaleiircle/MakeShapeOfCircle.kt
+++ b/arts/kaleiircle/src/main/kotlin/dev/oblac/gart/kaleiircle/MakeShapeOfCircle.kt
@@ -8,7 +8,7 @@ import dev.oblac.gart.math.cosDeg
 import dev.oblac.gart.math.sinDeg
 import org.jetbrains.skia.ClipMode
 import org.jetbrains.skia.ImageFilter
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Rect
 
 class MakeShapeOfCircle(private val d: Dimension) {
@@ -24,37 +24,42 @@ class MakeShapeOfCircle(private val d: Dimension) {
 
         val rect = Rect(cx - r, cy - r, cx + r, cy + r)
         val rect2 = Rect(cx - r2, cy - r2, cx + r2, cy + r2)
-        val arc1 = Path()
+        val arc1 = PathBuilder()
             .addArc(rect, 180f - angle, 180f)
             .lineTo(cx + r2 * cosDeg(-angle), cy + r2 * sinDeg(-angle))
             .addArc(rect2, -angle, -180f)
-            .lineTo(cx - r * cosDeg(-angle), cy - r * sinDeg(-angle))
+            .lineTo(cx - r * cosDeg(-angle), cy - r * sinDeg(-angle)).detach()
 
-        val triangle1 = Path()
+        val triangle1 = PathBuilder()
             .moveTo(cx, cy)
             .lineTo(cx + r2prim * cosDeg(-angle - alfa), cy + r2prim * sinDeg(-angle - alfa))
             .lineTo(cx + r2prim * cosDeg(-angle + alfa), cy + r2prim * sinDeg(-angle + alfa))
             .closePath()
-        val triangle1_2 = Path()
+            .detach()
+        val triangle1_2 = PathBuilder()
             .moveTo(cx, cy)
             .lineTo(cx + r2prim * cosDeg(-angle), cy + r2prim * sinDeg(-angle))
             .lineTo(cx + r2prim * cosDeg(-angle + alfa), cy + r2prim * sinDeg(-angle + alfa))
             .closePath()
-        val arc2 = Path()
+            .detach()
+        val arc2 = PathBuilder()
             .addArc(rect, -angle, 180f)
             .lineTo(cx - r2 * cosDeg(-angle), cy - r2 * sinDeg(-angle))
             .addArc(rect2, 180f - angle, -180f)
             .lineTo(cx + r * cosDeg(-angle), cy + r * sinDeg(-angle))
-        val triangle2 = Path()
+            .detach()
+        val triangle2 = PathBuilder()
             .moveTo(cx, cy)
             .lineTo(cx - r2prim * cosDeg(-angle - alfa), cy - r2prim * sinDeg(-angle - alfa))
             .lineTo(cx - r2prim * cosDeg(-angle + alfa), cy - r2prim * sinDeg(-angle + alfa))
             .closePath()
-        val triangle2_2 = Path()
+            .detach()
+        val triangle2_2 = PathBuilder()
             .moveTo(cx, cy)
             .lineTo(cx - r2prim * cosDeg(-angle), cy - r2prim * sinDeg(-angle))
             .lineTo(cx - r2prim * cosDeg(-angle + alfa), cy - r2prim * sinDeg(-angle + alfa))
             .closePath()
+            .detach()
         val arc1Color = fillOf(circle.colors.first)
             .apply {
                 imageFilter = ImageFilter.makeDropShadow(

--- a/arts/kaleiircle/src/main/kotlin/dev/oblac/gart/kaleiircle/MakeWaves.kt
+++ b/arts/kaleiircle/src/main/kotlin/dev/oblac/gart/kaleiircle/MakeWaves.kt
@@ -5,6 +5,7 @@ import dev.oblac.gart.Draw
 import dev.oblac.gart.math.sinDeg
 import org.jetbrains.skia.Paint
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 
 class MakeWaves(private val d: Dimension) {
     fun invoke(angle: Float = 0f, amplitude: Float = 20f, gap: Float = 10f, speed: Float = 2f): Draw {
@@ -13,13 +14,13 @@ class MakeWaves(private val d: Dimension) {
         var y = -amplitude
         while (y < d.h + amplitude) {
             var x = 0f
-            val p = Path().moveTo(x, y)
+            val p = PathBuilder().moveTo(x, y)
             while (x < d.w) {
                 val dy = amplitude * sinDeg(x * speed)
                 x++
                 p.lineTo(x, y + dy)
             }
-            paths.add(p)
+            paths.add(p.detach())
             y += gap
         }
 

--- a/arts/kaleiircle/src/main/kotlin/dev/oblac/gart/kaleiircle/Spiral.kt
+++ b/arts/kaleiircle/src/main/kotlin/dev/oblac/gart/kaleiircle/Spiral.kt
@@ -5,7 +5,7 @@ import dev.oblac.gart.Draw
 import dev.oblac.gart.gfx.strokeOf
 import dev.oblac.gart.math.cosDeg
 import dev.oblac.gart.math.sinDeg
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import kotlin.math.max
 
@@ -14,7 +14,7 @@ class MakeSpiral(private val d: Dimension) {
     operator fun invoke(dx: Float, dy: Float): Draw {
         val center = Point(d.cx + dx, d.cy + dy)
         val radius = max(d.w, d.h)
-        val path = Path()
+        val path = PathBuilder()
 
         for (angle in 0..3600) {
             val scaledRadius = radius * angle / 3600
@@ -28,6 +28,6 @@ class MakeSpiral(private val d: Dimension) {
             }
         }
 
-        return Draw { canvas, d -> canvas.drawPath(path, strokeOf(0x11000000, 4f)) }
+        return Draw { canvas, d -> canvas.drawPath(path.detach(), strokeOf(0x11000000, 4f)) }
     }
 }

--- a/arts/lettero/src/main/kotlin/dev/oblac/gart/lettero2/Lettero2.kt
+++ b/arts/lettero/src/main/kotlin/dev/oblac/gart/lettero2/Lettero2.kt
@@ -15,7 +15,7 @@ import dev.oblac.gart.math.rndf
 import dev.oblac.gart.math.rndi
 import dev.oblac.gart.text.drawTextOnPath
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 
 fun main() {
     val gart = Gart.of(
@@ -43,7 +43,7 @@ private fun draw(c: Canvas, d: Dimension) {
     var i = 0
 
     for (y in 0 until d.h + gap step gap) {
-        val path = Path()
+        val path = PathBuilder()
         path.moveTo(0f, y.toFloat())
 
         val gapx = 20
@@ -59,7 +59,7 @@ private fun draw(c: Canvas, d: Dimension) {
             }
         }
 
-        drawTextOnPath(c, path, random01(30), font, fillOf(pal[i]))
+        drawTextOnPath(c, path.detach(), random01(30), font, fillOf(pal[i]))
         i++
     }
     c.drawBorder(d, strokeOfBlack(40f))

--- a/arts/lines/src/main/kotlin/dev/oblac/gart/lines/outline/Outline.kt
+++ b/arts/lines/src/main/kotlin/dev/oblac/gart/lines/outline/Outline.kt
@@ -10,7 +10,7 @@ import dev.oblac.gart.gfx.*
 import dev.oblac.gart.jfa.Jfa
 import dev.oblac.gart.util.repeatSequence
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 
 fun main() {
@@ -56,12 +56,12 @@ private fun draw(c: Canvas, d: Dimension) {
     val path2 = isoscelesTriangle(Point(d.cx + 300f, d.cy - 150f), 100f, 300f, Degrees.of(220)).path
     val path3 = createNtagonPoints(4, d.cx + 250f, d.cy + 250f, 80f, 10f).toPath()
     val path4 = isoscelesTriangle(Point(d.cx - 250f, d.cy + 250f), 100f, 250f, Degrees.of(20)).path
-    val path = Path().apply {
+    val path = PathBuilder().apply {
         addPath(path1)
         addPath(path2)
         addPath(path3)
         addPath(path4)
-    }
+    }.detach()
 
     val w = 25f
     val total = (1024 / (2 * w)).toInt() + 6

--- a/arts/lines/src/main/kotlin/dev/oblac/gart/lines/stripes2/Stripes2.kt
+++ b/arts/lines/src/main/kotlin/dev/oblac/gart/lines/stripes2/Stripes2.kt
@@ -82,7 +82,7 @@ private fun drawStripe(
         pointCount = pointCount - 20
     )
 
-    val path = (path1 + path2.reversed()).toPath().closePath()
+    val path = (path1 + path2.reversed()).toClosedPath()
     c.drawPath(path, fillOf(RetroColors.white01))
 
     c.drawPath(path1.toPath(), strokeOf(RetroColors.black01, 3f))

--- a/arts/lines/src/main/kotlin/dev/oblac/gart/lines/swing/Swing.kt
+++ b/arts/lines/src/main/kotlin/dev/oblac/gart/lines/swing/Swing.kt
@@ -5,6 +5,7 @@ import dev.oblac.gart.color.RetroColors
 import dev.oblac.gart.gfx.strokeOf
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Rect
 
 fun main() {
@@ -58,7 +59,7 @@ private data class Swing(
 )
 
 private fun topLevelPath(d: Dimension, swing: Swing): Path {
-    val path = Path()
+    val path = PathBuilder()
     val y = swing.y
     path.moveTo(0f, y)
     path.lineTo(swing.right, y)
@@ -68,6 +69,6 @@ private fun topLevelPath(d: Dimension, swing: Swing): Path {
     val lastY = middleY + swing.gap
     path.arcTo(Rect(swing.left - swing.gap, middleY, swing.left, lastY), 270f, -180f, false)
     path.lineTo(d.wf, lastY)
-    return path
+    return path.detach()
 }
 

--- a/arts/lines/src/main/kotlin/dev/oblac/gart/lines/swing2/Swing2.kt
+++ b/arts/lines/src/main/kotlin/dev/oblac/gart/lines/swing2/Swing2.kt
@@ -4,10 +4,19 @@ import dev.oblac.gart.*
 import dev.oblac.gart.angle.Degrees
 import dev.oblac.gart.color.Colors
 import dev.oblac.gart.color.RetroColors
-import dev.oblac.gart.gfx.*
+import dev.oblac.gart.gfx.Line
+import dev.oblac.gart.gfx.Point
+import dev.oblac.gart.gfx.fillOf
+import dev.oblac.gart.gfx.strokeOf
 import dev.oblac.gart.gravitron.Gravitron
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
+
+private class Swing2Draw(g: Gartvas) : Drawing(g) {
+    override fun draw(c: Canvas, d: Dimension, f: Frames) {
+        draw2(c, d)
+    }
+}
 
 fun main() {
     val gart = Gart.of("swing2", 1024, 1024)
@@ -15,18 +24,12 @@ fun main() {
 
     val w = gart.window()
     val g = gart.gartvas()
-    val draw = MyDraw(g)
+    val draw = Swing2Draw(g)
 
 //    g.draw(draw)
 //    gart.saveImage(g)
 
     w.show(draw).hotReload(g)
-}
-
-private class MyDraw(g: Gartvas) : Drawing(g) {
-    override fun draw(c: Canvas, d: Dimension, f: Frames) {
-        draw2(c, d)
-    }
 }
 
 private val g1 = Gravitron(
@@ -50,8 +53,8 @@ private val g2 = Gravitron(
 
 private fun draw2(c: Canvas, d: Dimension) {
     c.clear(Colors.black)
-    c.drawCircle(g1.circle, strokeOfGreen(2f))
-    c.drawCircle(g2.circle, strokeOfGreen(2f))
+//    c.drawCircle(g1.circle, strokeOfGreen(2f))
+//    c.drawCircle(g2.circle, strokeOfGreen(2f))
 
     c.drawCircle(750f, 810f, 130f, fillOf(RetroColors.white01))
 
@@ -76,7 +79,7 @@ private fun draw2(c: Canvas, d: Dimension) {
 }
 
 private fun drawSwingLine(c: Canvas, l: Line, color: Int, i: Int, delta: Int = 0) {
-    val p = Path()
+    val p = PathBuilder()
     p.moveTo(l.a.x, l.a.y)
 
     val l2 = g1.applyTo(l, p)
@@ -90,10 +93,10 @@ private fun drawSwingLine(c: Canvas, l: Line, color: Int, i: Int, delta: Int = 0
             p.lineTo(l2.b.x, l2.b.y)
         }
     }
-    c.drawPath(p, strokeOf(color, 10f + delta))
+    c.drawPath(p.detach(), strokeOf(color, 10f + delta))
 }
 private fun drawSwingLine2(c: Canvas, l: Line, color: Int, i: Int, delta: Int = 0) {
-    val p = Path()
+    val p = PathBuilder()
     p.moveTo(l.a.x, l.a.y)
 
     val l2 = g1Prim.applyTo(l, p)
@@ -107,5 +110,5 @@ private fun drawSwingLine2(c: Canvas, l: Line, color: Int, i: Int, delta: Int = 
             p.lineTo(l2.b.x, l2.b.y)
         }
     }
-    c.drawPath(p, strokeOf(color, 10f + delta))
+    c.drawPath(p.detach(), strokeOf(color, 10f + delta))
 }

--- a/arts/lines/src/main/kotlin/dev/oblac/gart/lines/swing3/Swing3.kt
+++ b/arts/lines/src/main/kotlin/dev/oblac/gart/lines/swing3/Swing3.kt
@@ -7,7 +7,7 @@ import dev.oblac.gart.color.RetroColors
 import dev.oblac.gart.gfx.*
 import dev.oblac.gart.gravitron.Gravitron
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 
 fun main() {
     val gart = Gart.of("swing3", 1024, 1024)
@@ -64,7 +64,7 @@ private fun draw2(c: Canvas, d: Dimension) {
 }
 
 private fun drawSwingLine(c: Canvas,  d: Dimension, l: Line, i: Int) {
-    val p = Path()
+    val p = PathBuilder()
     p.moveTo(l.a.x, l.a.y)
 
     var currentLine = l
@@ -91,8 +91,9 @@ private fun drawSwingLine(c: Canvas,  d: Dimension, l: Line, i: Int) {
         p.lineTo(finalLine.b.x, finalLine.b.y)
     }
 
-    c.drawPointsAsCircles(p.toPoints(100).map {it.offset(0f,7f)}.subList(26, 51), strokeOf(RetroColors.white01, 10f))
-    c.drawPointsAsCircles(p.toPoints(100).map {it.offset(0f,7f)}.subList(26, 51), fillOfWhite())
-    c.drawPath(p, strokeOf(RetroColors.red01, 6f))
+    val pathD = p.detach()
+    c.drawPointsAsCircles(pathD.toPoints(100).map { it.offset(0f, 7f) }.subList(26, 51), strokeOf(RetroColors.white01, 10f))
+    c.drawPointsAsCircles(pathD.toPoints(100).map { it.offset(0f, 7f) }.subList(26, 51), fillOfWhite())
+    c.drawPath(pathD, strokeOf(RetroColors.red01, 6f))
 }
 

--- a/arts/lines/src/main/kotlin/dev/oblac/gart/lines/tapes/OverlappingPath.kt
+++ b/arts/lines/src/main/kotlin/dev/oblac/gart/lines/tapes/OverlappingPath.kt
@@ -2,6 +2,7 @@ package dev.oblac.gart.lines.tapes
 
 import dev.oblac.gart.gfx.Line
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import kotlin.math.PI
 import kotlin.math.cos
@@ -168,7 +169,7 @@ fun generateChaoticOverlappingPath(
         points.add(Point(x, y))
     }
 
-    val path = Path()
+    val path = PathBuilder()
     var currentIndex = random.nextInt(numPoints)
 
     // Start the path
@@ -199,5 +200,5 @@ fun generateChaoticOverlappingPath(
     // Close the path
     path.closePath()
 
-    return path
+    return path.detach()
 }

--- a/arts/rectapart/src/main/kotlin/dev/oblac/gart/rectapart/RectAPart.kt
+++ b/arts/rectapart/src/main/kotlin/dev/oblac/gart/rectapart/RectAPart.kt
@@ -5,7 +5,7 @@ import dev.oblac.gart.color.Colors
 import dev.oblac.gart.gfx.createCircleOfPoints
 import dev.oblac.gart.gfx.randomPointBetween
 import dev.oblac.gart.gfx.strokeOfWhite
-import dev.oblac.gart.gfx.toPath
+import dev.oblac.gart.gfx.toClosedPath
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.PathEffect
 import org.jetbrains.skia.Point
@@ -16,6 +16,9 @@ fun main() {
 
     val g = gart.gartvas()
 
+    // ⚠️ There was a bug in Skiko that produced that image.
+    // I am not able to reproduce anymore.
+
     // draw on canvas
     g.draw { c, _ ->
         c.clear(Colors.black)
@@ -23,8 +26,9 @@ fun main() {
 //        c.clipRect(Rect.makeWH(500f, 500f))
 //        c.save()
         repeat(40) {
+            draw(c, 3)
 //            draw(c, 10)
-            draw(c, 12)
+//            draw(c, 12)
 //            draw(c, 14)
 //            draw(c, 15)
         }
@@ -42,7 +46,7 @@ private fun draw(c: Canvas, type: Int) {
 
     var s = shape
     repeat(20) {
-        c.drawPath(s.toPath().closePath(), strokeOfWhite(0.5f).apply {
+        c.drawPath(s.toClosedPath(), strokeOfWhite(0.5f).apply {
             this.alpha = 100
             this.pathEffect = PathEffect.makeDiscrete(2f, 2f, 173)
         })

--- a/arts/rects/src/main/kotlin/dev/oblac/gart/rects/Rects.kt
+++ b/arts/rects/src/main/kotlin/dev/oblac/gart/rects/Rects.kt
@@ -47,12 +47,13 @@ private fun drawRandomRect(canvas: Canvas, point: Point, r: Float, p: Paint) {
 }
 
 private fun pathOf(left: Point, bottom: Point, right: Point, top: Point): Path {
-    return Path()
+    return PathBuilder()
         .moveTo(left)
         .lineTo(bottom)
         .lineTo(right)
         .lineTo(top)
         .closePath()
+        .detach()
 }
 
 private fun rnd(delta: Float) = (Math.random() * 2 * delta).toFloat() - delta

--- a/arts/rotoro/src/main/kotlin/dev/oblac/gart/rotoro/Rotoro2.kt
+++ b/arts/rotoro/src/main/kotlin/dev/oblac/gart/rotoro/Rotoro2.kt
@@ -3,7 +3,6 @@ package dev.oblac.gart.rotoro
 import dev.oblac.gart.Gart
 import dev.oblac.gart.color.NipponColors
 import dev.oblac.gart.gfx.*
-import dev.oblac.gart.gfx.intersectionsOf
 import dev.oblac.gart.math.rndb
 import org.jetbrains.skia.*
 
@@ -67,7 +66,7 @@ private fun draw(canvas: Canvas, canvasWidth: Int) {
 
     // Draw the longest path
     val layer1 = paths[3].drop(1).dropLast(1)  // the first line is root tree, not correct
-    val p = Path()
+    val p = PathBuilder()
     layer1.forEachIndexed { ndx, line ->
         if (ndx == 0) {
             p.moveTo(line.a.x, line.a.y)
@@ -102,11 +101,12 @@ private fun draw(canvas: Canvas, canvasWidth: Int) {
     }
     p.closePath()
 
-    canvas.drawPath(p, strokePaint2)
+    val pathD = p.detach()
+    canvas.drawPath(pathD, strokePaint2)
 
     // Draw all circles
     circles.forEach {
-        val i = isCircleInPath(p, it)
+        val i = isCircleInPath(pathD, it)
         when (i) {
             IntersectionType.NONE -> canvas.drawCircle(it, if (rndb(3, 10)) accentPaint3 else strokePaint)
             IntersectionType.INTERSECT -> canvas.drawCircle(it, fillOfWhite())
@@ -125,9 +125,9 @@ private fun isCircleInPath(path: Path, circle: Circle): IntersectionType {
     val cy = circle.center.y
     val radius = circle.radius
 
-    val circlePath = Path().apply {
-        addOval(Rect(cx - radius, cy - radius, cx + radius, cy + radius))
-    }
+    val circlePath = PathBuilder()
+        .addOval(Rect(cx - radius, cy - radius, cx + radius, cy + radius))
+        .detach()
 
     val circleRegion = circlePath.toRegion()
 

--- a/arts/sf/src/main/kotlin/dev/oblac/gart/sf/SF1.kt
+++ b/arts/sf/src/main/kotlin/dev/oblac/gart/sf/SF1.kt
@@ -5,7 +5,7 @@ import dev.oblac.gart.Gart
 import dev.oblac.gart.color.RetroColors
 import dev.oblac.gart.gfx.*
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import kotlin.math.cos
 import kotlin.math.sin
@@ -56,12 +56,12 @@ private fun draw(c: Canvas, d: Dimension) {
             val nextLine = revs[index + 1]
 
             // draw path first
-            val path = Path()
+            val path = PathBuilder()
             path.moveTo(nextLine.a)
             path.lineTo(nextLine.b)
             path.lineTo(d.wf, d.hf)
             path.closePath()
-            c.drawPath(path, fillOf(colorBack))
+            c.drawPath(path.detach(), fillOf(colorBack))
 
             // draw the line
             c.drawLine(nextLine, strokeOf(colorLine, strokeWidth))

--- a/arts/sf/src/main/kotlin/dev/oblac/gart/sf/SF8.kt
+++ b/arts/sf/src/main/kotlin/dev/oblac/gart/sf/SF8.kt
@@ -64,11 +64,11 @@ private fun drawCloud(c: Canvas, d: Dimension) {
 //        c.drawCircle(Circle(it, rndf(120f, 150f)), fillOf(colorBold))
 //    }
 
-    val path = p.toPath()
+    val path = p.toPathBuilder()
     path.lineTo(d.rightBottom)
     path.lineTo(d.leftBottom)
     path.closePath()
-    c.drawPath(path, fillOf(colorInk))
+    c.drawPath(path.detach(), fillOf(colorInk))
 //    c.drawPath(path, strokeOf(colorInk, 2f))
 
 //    p.forEach {

--- a/arts/sixsix/src/main/kotlin/dev/oblac/gart/sixsix/cells.kt
+++ b/arts/sixsix/src/main/kotlin/dev/oblac/gart/sixsix/cells.kt
@@ -5,6 +5,7 @@ import dev.oblac.gart.angle.Degrees
 import dev.oblac.gart.color.Palette
 import dev.oblac.gart.gfx.*
 import dev.oblac.gart.math.GOLDEN_RATIOf
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import org.jetbrains.skia.RRect
 import org.jetbrains.skia.Rect
@@ -626,7 +627,7 @@ private fun cell35(g: Gartvas, p: Palette) {
     val radius = d.wf.coerceAtMost(d.hf * RATIO) / 2f
     val innerRadius = radius * 0.382f // Golden ratio for pentagram
 
-    val path = org.jetbrains.skia.Path()
+    val path = PathBuilder()
     for (i in 0 until 10) {
         val angle = (i * 36f - 90f) * Math.PI.toFloat() / 180f
         val r = if (i % 2 == 0) radius else innerRadius
@@ -640,7 +641,7 @@ private fun cell35(g: Gartvas, p: Palette) {
         }
     }
     path.closePath()
-    c.drawPath(path, fillOf(p[1]))
+    c.drawPath(path.detach(), fillOf(p[1]))
 }
 
 private fun cell36(g: Gartvas, p: Palette) {

--- a/arts/stripes/src/main/kotlin/dev/oblac/gart/stripes/Line.kt
+++ b/arts/stripes/src/main/kotlin/dev/oblac/gart/stripes/Line.kt
@@ -5,7 +5,10 @@ import dev.oblac.gart.gfx.strokeOfWhite
 import dev.oblac.gart.math.GaussianFunction
 import dev.oblac.gart.math.map
 import dev.oblac.gart.noise.PerlinNoise
-import org.jetbrains.skia.*
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.PaintStrokeCap
+import org.jetbrains.skia.PathBuilder
+import org.jetbrains.skia.Point
 import kotlin.math.abs
 import kotlin.random.Random
 
@@ -42,10 +45,10 @@ class Line(private val offsetY: Float) {
 
         var left: Float? = null
 
-        val path = Path()
-            .apply {
-                fillMode = PathFillMode.EVEN_ODD
-            }
+        val path = PathBuilder()
+//            .apply {
+//                fillMode = PathFillMode.EVEN_ODD
+//            }
             .moveTo(0f, offsetY)
 
         for (i in 0 until segments) {

--- a/arts/stripes/src/main/kotlin/dev/oblac/gart/stripes/tolerance/Tolerance.kt
+++ b/arts/stripes/src/main/kotlin/dev/oblac/gart/stripes/tolerance/Tolerance.kt
@@ -8,7 +8,7 @@ import dev.oblac.gart.angle.sinf
 import dev.oblac.gart.color.BgColors
 import dev.oblac.gart.color.Palettes
 import dev.oblac.gart.gfx.fillOf
-import dev.oblac.gart.gfx.toPath
+import dev.oblac.gart.gfx.toPathBuilder
 import dev.oblac.gart.math.rndf
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Point
@@ -45,11 +45,11 @@ private fun draw(c: Canvas, d: Dimension) {
     }
 
     // draw white to the left
-    val path = ps.toPath()
+    val path = ps.toPathBuilder()
     path.lineTo(0f, d.h.toFloat())
     path.lineTo(0f, 0f)
     path.closePath()
-    c.drawPath(path, fillOf(BgColors.clottedCream))
+    c.drawPath(path.detach(), fillOf(BgColors.clottedCream))
 
     // draw rectangles
     val w = 200

--- a/arts/switchboard/src/main/kotlin/dev/oblac/gart/switchboard/Switchboard.kt
+++ b/arts/switchboard/src/main/kotlin/dev/oblac/gart/switchboard/Switchboard.kt
@@ -214,7 +214,7 @@ data class Switch(val x: Int, val y: Int, val type: SwitchType, val color: Int =
     ) {
         canvas.save()
         val rect = Rect.of(x0, y0, x1, y1)
-        val clipPath = Path().addRect(rect)
+        val clipPath = PathBuilder().addRect(rect).detach()
         canvas.clipPath(clipPath)
         canvas.drawRect(rect.grow(2f), if (rndb()) dashPaint else dashPaint2)
         canvas.restore()

--- a/arts/ticktiletock/src/main/kotlin/dev/oblac/gart/ticktiletock/Painters.kt
+++ b/arts/ticktiletock/src/main/kotlin/dev/oblac/gart/ticktiletock/Painters.kt
@@ -11,8 +11,8 @@ import kotlin.random.Random
 
 val paintTile2: (Tile) -> Draw = { tile ->
     val line = when (Random.nextBoolean()) {
-        false -> Path().moveTo(tile.x, tile.y).lineTo(tile.x + tile.d, tile.y + tile.d)
-        true -> Path().moveTo(tile.x, tile.y + tile.d).lineTo(tile.x + tile.d, tile.y)
+        false -> PathBuilder().moveTo(tile.x, tile.y).lineTo(tile.x + tile.d, tile.y + tile.d).detach()
+        true -> PathBuilder().moveTo(tile.x, tile.y + tile.d).lineTo(tile.x + tile.d, tile.y).detach()
     }
 
     val stroke = strokeOfBlack(4f).apply {
@@ -22,11 +22,11 @@ val paintTile2: (Tile) -> Draw = { tile ->
 }
 val paintTile4: (Tile) -> Draw = { tile ->
     val line = when (Random.nextInt(4)) {
-        0 -> Path().moveTo(tile.x, tile.y).lineTo(tile.x + tile.d, tile.y + tile.d)
-        1 -> Path().moveTo(tile.x, tile.y + tile.d).lineTo(tile.x + tile.d, tile.y)
-        2 -> Path().moveTo(tile.x, tile.y + tile.d / 2).lineTo(tile.x + tile.d, tile.y + tile.d / 2)
-        else -> Path().moveTo(tile.x + tile.d / 2, tile.y).lineTo(tile.x + tile.d / 2, tile.y + tile.d)
-    }
+        0 -> PathBuilder().moveTo(tile.x, tile.y).lineTo(tile.x + tile.d, tile.y + tile.d)
+        1 -> PathBuilder().moveTo(tile.x, tile.y + tile.d).lineTo(tile.x + tile.d, tile.y)
+        2 -> PathBuilder().moveTo(tile.x, tile.y + tile.d / 2).lineTo(tile.x + tile.d, tile.y + tile.d / 2)
+        else -> PathBuilder().moveTo(tile.x + tile.d / 2, tile.y).lineTo(tile.x + tile.d / 2, tile.y + tile.d)
+    }.detach()
 
     val stroke = strokeOf(Palettes.cool1.random(), 4f).apply {
         strokeCap = PaintStrokeCap.SQUARE
@@ -36,14 +36,14 @@ val paintTile4: (Tile) -> Draw = { tile ->
 }
 val paintCircle: (Tile) -> Draw = { tile ->
     val rnd = Random.nextInt(4)
-    val circle = Path().addCircle(tile.x + tile.d / 2, tile.y + tile.d / 2, rnd * tile.d / 8)
+    val circle = PathBuilder().addCircle(tile.x + tile.d / 2, tile.y + tile.d / 2, rnd * tile.d / 8).detach()
     val stroke = strokeOf(Palettes.cool1.random(), 4f)
 
     Draw { canvas, _ -> canvas.drawPath(circle, stroke) }
 }
 val paintCircleBW: (Tile) -> Draw = { tile ->
     val rnd = Random.nextInt(4)
-    val circle = Path().addCircle(tile.x + tile.d / 2, tile.y + tile.d / 2, rnd * tile.d / 8)
+    val circle = PathBuilder().addCircle(tile.x + tile.d / 2, tile.y + tile.d / 2, rnd * tile.d / 8).detach()
     val stroke = fillOfBlack()
 
     Draw { canvas, _ -> canvas.drawPath(circle, stroke) }

--- a/example/src/main/kotlin/dev/oblac/gart/ExampleGravitron.kt
+++ b/example/src/main/kotlin/dev/oblac/gart/ExampleGravitron.kt
@@ -5,7 +5,7 @@ import dev.oblac.gart.color.Colors
 import dev.oblac.gart.gfx.*
 import dev.oblac.gart.gravitron.Gravitron
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 
 fun main() {
     val gart = Gart.of("ExampleGravitron", 1024, 1024)
@@ -35,10 +35,10 @@ private fun draw(c: Canvas, d: Dimension) {
         a = Point(0f, 500f),
         b = Point(d.cx, d.cy - 200f)
     ).let { line ->
-        val p = Path().moveTo(line.a)
+        val p = PathBuilder().moveTo(line.a)
         g.applyTo(line, p)
             ?.let { c.drawLine(it, strokeOfRed(2f)) }
-        c.drawPath(p, strokeOfRed(8f))
+        c.drawPath(p.detach(), strokeOfRed(8f))
     }
 
     // line: right to left, top to bottom
@@ -46,10 +46,10 @@ private fun draw(c: Canvas, d: Dimension) {
         a = Point(1024f, 500f),
         b = Point(d.cx, d.cy - 200f)
     ).let { line ->
-        val p = Path().moveTo(line.a)
+        val p = PathBuilder().moveTo(line.a)
         g.applyTo(line, p)
             ?.let { c.drawLine(it, strokeOfBlue(2f)) }
-        c.drawPath(p, strokeOfBlue(8f))
+        c.drawPath(p.detach(), strokeOfBlue(8f))
     }
 
     // line: left to right, bottom to top
@@ -57,10 +57,10 @@ private fun draw(c: Canvas, d: Dimension) {
         a = Point(0f, 500f),
         b = Point(d.cx, d.cy + 200f)
     ).let { line ->
-        val p = Path().moveTo(line.a)
+        val p = PathBuilder().moveTo(line.a)
         g.applyTo(line, p)
             ?.let { c.drawLine(it, strokeOfYellow(2f)) }
-        c.drawPath(p, strokeOfYellow(8f))
+        c.drawPath(p.detach(), strokeOfYellow(8f))
     }
 
     // line: right to left, bottom to top
@@ -68,9 +68,9 @@ private fun draw(c: Canvas, d: Dimension) {
         a = Point(1024f, 500f),
         b = Point(d.cx, d.cy + 200f)
     ).let { line ->
-        val p = Path().moveTo(line.a)
+        val p = PathBuilder().moveTo(line.a)
         g.applyTo(line, p)
             ?.let { c.drawLine(it, strokeOfMagenta(2f)) }
-        c.drawPath(p, strokeOfMagenta(8f))
+        c.drawPath(p.detach(), strokeOfMagenta(8f))
     }
 }

--- a/example/src/main/kotlin/dev/oblac/gart/ExampleSpirograph.kt
+++ b/example/src/main/kotlin/dev/oblac/gart/ExampleSpirograph.kt
@@ -7,7 +7,7 @@ import dev.oblac.gart.spirograph.Spirograph
 import dev.oblac.gart.spirograph.createSpirograph
 import dev.oblac.gart.util.circular
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathOp
 import org.jetbrains.skia.Rect
 
@@ -40,15 +40,15 @@ private fun buildSpiro(): Spirograph {
             val centerY = canvasSize / 2
 
             // Position the circles to form a clover shape centered in the canvas
-            val circle1 = Path().apply {
+            val circle1 = PathBuilder().apply {
                 addOval(Rect.makeXYWH(centerX - radius, centerY - radius * 1.5f, radius * 2, radius * 2))
-            }
-            val circle2 = Path().apply {
+            }.detach()
+            val circle2 = PathBuilder().apply {
                 addOval(Rect.makeXYWH(centerX - radius * 1.2f, centerY - radius / 2f, radius * 2, radius * 2))
-            }
-            val circle3 = Path().apply {
+            }.detach()
+            val circle3 = PathBuilder().apply {
                 addOval(Rect.makeXYWH(centerX + radius * 0.5f, centerY - radius / 2f, radius * 2, radius * 2))
-            }
+            }.detach()
             val result = combinePathsWithOp(PathOp.UNION, circle1, circle2, circle3)
             result.toPoints(100).toClosedPath()
         }

--- a/example/src/main/kotlin/dev/oblac/gart/ToolGradientGenerator.kt
+++ b/example/src/main/kotlin/dev/oblac/gart/ToolGradientGenerator.kt
@@ -267,7 +267,7 @@ private fun drawWavePlot(c: Canvas, d: Dimension, ggen: GGen, waves: Waves) {
             else -> Colors.black
         }
 
-        val path = Path()
+        val path = PathBuilder()
 
         for (i in 0..samples) {
             // Normalized x coordinate (0 to 1)
@@ -292,7 +292,7 @@ private fun drawWavePlot(c: Canvas, d: Dimension, ggen: GGen, waves: Waves) {
             if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
         }
 
-        c.drawPath(path, paint)
+        c.drawPath(path.detach(), paint)
     }
 }
 

--- a/gart/build.gradle.kts
+++ b/gart/build.gradle.kts
@@ -28,7 +28,7 @@ val targetArch = when (osArch) {
     else -> error("Unsupported arch: $osArch")
 }
 
-val version = "0.9.47"
+val version = "0.144.1"
 val target = "${targetOs}-${targetArch}"
 
 dependencies {

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/RectIsometric.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/RectIsometric.kt
@@ -5,6 +5,7 @@ import dev.oblac.gart.angle.Degrees
 import dev.oblac.gart.angle.cos
 import dev.oblac.gart.angle.sin
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 
 /**
@@ -35,12 +36,13 @@ sealed class RectIsometric(x: Float, y: Float, a: Float, b: Float, alpha: Angle,
     }
 
     fun path(): Path {
-        return Path()
+        return PathBuilder()
             .moveTo(left)
             .lineTo(bottom)
             .lineTo(right)
             .lineTo(top)
             .closePath()
+            .detach()
     }
 
     fun width(): Float {

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/Triangle.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/Triangle.kt
@@ -8,7 +8,7 @@ import dev.oblac.gart.math.dist
 import dev.oblac.gart.math.rnd
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Paint
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import org.jetbrains.skia.Rect
 import kotlin.math.*
@@ -16,11 +16,12 @@ import kotlin.math.*
 data class Triangle(val a: Point, val b: Point, val c: Point) {
     fun points() = arrayOf(a, b, c)
 
-    val path = Path()
+    val path = PathBuilder()
         .moveTo(a)
         .lineTo(b)
         .lineTo(c)
         .closePath()
+        .detach()
 
     val edges = arrayOf(
         Line(a, b), Line(b, c), Line(c, a)

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/circle.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/circle.kt
@@ -7,7 +7,7 @@ import dev.oblac.gart.angle.sin
 import dev.oblac.gart.vector.Vector2
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Paint
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import org.jetbrains.skia.Rect
 import kotlin.math.pow
@@ -100,7 +100,7 @@ data class Circle(val x: Float, val y: Float, val radius: Float) {
         return points
     }
 
-    fun toPath() = Path().addCircle(x, y, radius)
+    fun toPath() = PathBuilder().addCircle(x, y, radius).detach()
 
     /**
      * Scales the circle by the given factor, keeping the center point unchanged.

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/human.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/human.kt
@@ -43,7 +43,7 @@ fun Canvas.drawHumanRect(r: Rect, color: Paint) {
             humanLinePoints(p[2], p[3]) +
             humanLinePoints(p[3], p[0])
 
-    val s = chaikinSmooth(path).toPath().closePath()
+    val s = chaikinSmooth(path).toClosedPath()
 
     this.drawPath(s, color)
 }

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/line.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/line.kt
@@ -123,10 +123,10 @@ data class Line(val a: Point, val b: Point) {
     }
 
     fun toPath(): Path {
-        val path = Path()
+        val path = PathBuilder()
         path.moveTo(a.x, a.y)
         path.lineTo(b.x, b.y)
-        return path
+        return path.detach()
     }
 
     /**

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/moon.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/moon.kt
@@ -45,17 +45,16 @@ data class Moon(
                 // half-moon
                 canvas.save()
 
-                val mainPath = Path()
+                val mainPath = PathBuilder()
                 if (sign > 0) {
                     mainPath.addRect(Rect(cx - radius, cy - radius, cx, cy + radius))
                 } else {
                     mainPath.addRect(Rect(cx, cy - radius, cx + radius, cy + radius))
                 }
-                canvas.clipPath(mainPath, ClipMode.DIFFERENCE)
+                canvas.clipPath(mainPath.detach(), ClipMode.DIFFERENCE)
                 canvas.drawCircle(circle, moonPaint)
 
                 canvas.restore()
-
             }
         }
     }
@@ -76,9 +75,9 @@ data class Moon(
 
         canvas.save()
 
-        val mainPath = Path()
+        val mainPath = PathBuilder()
         mainPath.addCircle(c3)
-        canvas.clipPath(mainPath, clipMode)
+        canvas.clipPath(mainPath.detach(), clipMode)
         canvas.drawCircle(circle, moonPaint)
 
         canvas.restore()

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/paints.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/paints.kt
@@ -63,8 +63,8 @@ fun fillOfGreen() = fillOf(Color.GREEN)
  * Returns a Paint object that represents a hatch (dotted) pattern.
  */
 fun hatchPaint(color: Int, density: Float = 5f, dotWidth: Float = 1f, strokeWidth: Float = 3f) = Paint().apply {
-    val hatch = Path().addCircle(0f, 0f, dotWidth)
-    this.pathEffect = PathEffect.makePath2D(Matrix33.makeScale(density, density), hatch)
+    val hatch = PathBuilder().addCircle(0f, 0f, dotWidth)
+    this.pathEffect = PathEffect.makePath2D(Matrix33.makeScale(density, density), hatch.detach())
     this.color = color
     this.strokeWidth = strokeWidth
 }

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/pathBuilder.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/pathBuilder.kt
@@ -1,0 +1,6 @@
+package dev.oblac.gart.gfx
+
+import org.jetbrains.skia.PathBuilder
+
+fun PathBuilder.addCircle(circle: Circle) =
+    this.addCircle(circle.center.x, circle.center.y, circle.radius)

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/poly4.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/poly4.kt
@@ -4,7 +4,7 @@ import dev.oblac.gart.angle.Angle
 import dev.oblac.gart.math.rnd
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Paint
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import kotlin.math.cos
 import kotlin.math.sin
@@ -47,13 +47,13 @@ data class Poly4(
         )
     }
 
-    val path = Path().apply {
+    val path = PathBuilder().apply {
         moveTo(a.x, a.y)
         lineTo(b.x, b.y)
         lineTo(c.x, c.y)
         lineTo(d.x, d.y)
         closePath()
-    }
+    }.detach()
 
     fun shrink(factor: Float): Poly4 {
         val center = center()

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/rectangle.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/rectangle.kt
@@ -2,6 +2,7 @@ package dev.oblac.gart.gfx
 
 import dev.oblac.gart.Dimension
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 import org.jetbrains.skia.RRect
 import org.jetbrains.skia.Rect
@@ -20,13 +21,13 @@ fun Rect.points(): Array<Point> {
 
 fun Rect.path(): Path {
     val points = this.points()
-    return Path().apply {
+    return PathBuilder().apply {
         moveTo(points[0])
         lineTo(points[1])
         lineTo(points[2])
         lineTo(points[3])
         closePath()
-    }
+    }.detach()
 }
 
 fun Rect.move(delta: Float): Rect {

--- a/gart/src/main/kotlin/dev/oblac/gart/gfx/ring.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gfx/ring.kt
@@ -87,7 +87,7 @@ private fun drawRingPart(
     c.rotate(angle.degrees, center.x, center.y)
 
     // Create a path for the ring segment
-    val path = Path()
+    val path = PathBuilder()
 
     // Add the outer arc
     path.addArc(outerRect, startAngle, sweepAngle)
@@ -105,7 +105,7 @@ private fun drawRingPart(
 
     path.closePath()
 
-    c.drawPath(path, paint)
+    c.drawPath(path.detach(), paint)
 
     c.restore()
 }

--- a/gart/src/main/kotlin/dev/oblac/gart/gravitron/Gravitron.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/gravitron/Gravitron.kt
@@ -5,7 +5,7 @@ import dev.oblac.gart.angle.Degrees
 import dev.oblac.gart.gfx.Circle
 import dev.oblac.gart.gfx.Line
 import dev.oblac.gart.math.Transform
-import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathDirection
 import org.jetbrains.skia.PathEllipseArc
 import org.jetbrains.skia.Point
@@ -26,7 +26,7 @@ data class Gravitron(
     val c = Point(x, y)
     val circle = Circle(x, y, radius)
 
-    fun applyTo(line: Line, path: Path): Line? {
+    fun applyTo(line: Line, path: PathBuilder): Line? {
         path.lineTo(line.a.x, line.a.y)
 
         // find perpendicular point on the line

--- a/gart/src/main/kotlin/dev/oblac/gart/jfa/Jfa.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/jfa/Jfa.kt
@@ -5,6 +5,7 @@ import dev.oblac.gart.Gartvas
 import dev.oblac.gart.gfx.fillOf
 import org.jetbrains.skia.Color
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import kotlin.math.sqrt
 
 /**
@@ -191,7 +192,7 @@ class JfaResult(
     }
 
     private fun marchingSquares(field: FloatArray, width: Int, height: Int, threshold: Float): Path {
-        val path = Path()
+        val path = PathBuilder()
 
         fun getField(x: Int, y: Int): Float {
             if (x !in 0 until width || y !in 0 until height) return Float.MAX_VALUE
@@ -243,7 +244,7 @@ class JfaResult(
         }
 
         // Connect segments into paths
-        if (segments.isEmpty()) return path
+        if (segments.isEmpty()) return path.detach()
 
         val remaining = segments.toMutableList()
         while (remaining.isNotEmpty()) {
@@ -294,7 +295,7 @@ class JfaResult(
             }
         }
 
-        return path
+        return path.detach()
     }
 
     private fun dist(a: Pair<Float, Float>, b: Pair<Float, Float>): Float {

--- a/gart/src/main/kotlin/dev/oblac/gart/smooth/bSpline.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/smooth/bSpline.kt
@@ -1,6 +1,7 @@
 package dev.oblac.gart.smooth
 
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 
 fun List<Point>.toBSpline(segments: Int = 20) = bSpline(this, segments)
@@ -14,7 +15,7 @@ fun bSpline(points: List<Point>, segments: Int = 20): Path {
         throw IllegalArgumentException("The points need to have at least 4 points")
     }
 
-    val path = Path()
+    val path = PathBuilder()
 
     // Calculate first point
     val startPoint = bSplinePoint(points[0], points[0], points[1], points[2], 0f)
@@ -34,7 +35,7 @@ fun bSpline(points: List<Point>, segments: Int = 20): Path {
         }
     }
 
-    return path
+    return path.detach()
 }
 
 private fun bSplinePoint(p0: Point, p1: Point, p2: Point, p3: Point, t: Float): Point {

--- a/gart/src/main/kotlin/dev/oblac/gart/smooth/cardinalSpline.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/smooth/cardinalSpline.kt
@@ -2,6 +2,7 @@ package dev.oblac.gart.smooth
 
 import dev.oblac.gart.gfx.toPath
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 
 fun List<Point>.toCardinalSpline(tension: Float = 0.5f, segments: Int = 20) =
@@ -17,7 +18,7 @@ fun cardinalSpline(
 ): Path {
     if (points.size < 2) return points.toPath()
 
-    val path = Path()
+    val path = PathBuilder()
     path.moveTo(points[0].x, points[0].y)
 
     for (i in 0 until points.size - 1) {
@@ -50,5 +51,5 @@ fun cardinalSpline(
         }
     }
 
-    return path
+    return path.detach()
 }

--- a/gart/src/main/kotlin/dev/oblac/gart/smooth/catmullRomSpline.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/smooth/catmullRomSpline.kt
@@ -2,6 +2,7 @@ package dev.oblac.gart.smooth
 
 import dev.oblac.gart.gfx.toPath
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 
 fun List<Point>.toCatmullRomSpline(segments: Int = 20) = catmullRomSpline(this, segments)
@@ -15,7 +16,7 @@ fun List<Point>.toCatmullRomSpline(segments: Int = 20) = catmullRomSpline(this, 
 fun catmullRomSpline(points: List<Point>, segments: Int = 20): Path {
     if (points.size < 2) return points.toPath()
 
-    val path = Path()
+    val path = PathBuilder()
     path.moveTo(points[0].x, points[0].y)
 
     for (i in 0 until points.size - 1) {
@@ -30,7 +31,7 @@ fun catmullRomSpline(points: List<Point>, segments: Int = 20): Path {
             path.lineTo(point.x, point.y)
         }
     }
-    return path
+    return path.detach()
 }
 
 private fun catmullRomPoint(p0: Point, p1: Point, p2: Point, p3: Point, t: Float): Point {

--- a/gart/src/main/kotlin/dev/oblac/gart/smooth/chaikin.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/smooth/chaikin.kt
@@ -1,7 +1,7 @@
 package dev.oblac.gart.smooth
 
 import dev.oblac.gart.gfx.copy
-import dev.oblac.gart.gfx.toPath
+import dev.oblac.gart.gfx.toClosedPath
 import org.jetbrains.skia.Point
 
 /**
@@ -100,4 +100,4 @@ fun List<Point>.toChaikinSmooth(
     iterations: Int = 1,
     closed: Boolean = false,
     bias: Double = 0.25
-) = chaikinSmooth(this, iterations, closed, bias).toPath().closePath()
+) = chaikinSmooth(this, iterations, closed, bias).toClosedPath()

--- a/gart/src/main/kotlin/dev/oblac/gart/smooth/smoothQuadratic.kt
+++ b/gart/src/main/kotlin/dev/oblac/gart/smooth/smoothQuadratic.kt
@@ -2,6 +2,7 @@ package dev.oblac.gart.smooth
 
 import dev.oblac.gart.gfx.toPath
 import org.jetbrains.skia.Path
+import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.Point
 
 fun List<Point>.toSmoothQuadraticPath() = drawSmoothQuadratic(this)
@@ -17,7 +18,7 @@ fun List<Point>.toSmoothQuadraticPath() = drawSmoothQuadratic(this)
 fun drawSmoothQuadratic(points: List<Point>): Path {
     if (points.size < 2) return points.toPath()
 
-    val path = Path()
+    val path = PathBuilder()
     path.moveTo(points[0].x, points[0].y)
 
     if (points.size == 2) {
@@ -44,5 +45,5 @@ fun drawSmoothQuadratic(points: List<Point>): Path {
         path.lineTo(points.last().x, points.last().y)
     }
 
-    return path
+    return path.detach()
 }


### PR DESCRIPTION
## Summary by Sourcery

Adapt graphics utilities and sketches to Skiko 0.144.1 path APIs and builder pattern across the project.

Enhancements:
- Refactor path creation throughout the codebase to use PathBuilder with explicit detach() when finalized.
- Introduce helper utilities for building and closing paths (e.g., pathBuilderOf, closedPathOf, PathBuilder.addCircle) and propagate their use across geometry helpers and smoothing functions.
- Adjust Gravitron and various drawing routines to operate on PathBuilder where appropriate and then convert to Path for rendering.
- Tweak several art/sketch examples to align with the updated path behavior, including clipping, transformations, and translation-based effects.

Build:
- Bump Skiko dependency target version to 0.144.1 in the build configuration.